### PR TITLE
added usage of nice when ionice is not available

### DIFF
--- a/phpmalwarefinder
+++ b/phpmalwarefinder
@@ -2,6 +2,8 @@
 
 YARA=$(which yara)
 CONFIG_PATH='/etc/phpmalwarefinder/malwares.yara'
+IONICE_BIN=$(which ionice)
+NICE_BIN=$(which nice)
 
 if [ ! -f "$YARA" ]
 then
@@ -11,6 +13,18 @@ fi
 if [ ! -f "$CONFIG_PATH" ]
 then
 	CONFIG_PATH='./malwares.yara'
+fi
+
+if [ -f "${IONICE_BIN}" ]
+then
+	NICE=${IONICE_BIN}
+	NICE_OPTS="-c 3"
+else
+	if [ -f "${NICE_BIN}" ]
+	then
+		NICE=${NICE_BIN}
+		NICE_OPTS="-n 20"
+	fi
 fi
 
 show_help() {
@@ -65,6 +79,12 @@ then
 	exit 1
 fi
 
+if [ ! -e ${NICE} ]
+then
+	echo "no nice program available. Please install ionice or nice."
+	exit 1
+fi
+
 OPTS="${OPTS} -r ${CONFIG_PATH}"
 
-ionice -c3 $YARA $OPTS $@
+${NICE} ${NICE_OPTS} $YARA $OPTS $@


### PR DESCRIPTION
On some platforms (e.g. NetBSD, OS X), ionice is not available by default. This patch checks for ionice availability, and switch back to nice if needed. In the case none of them are installed, an error is displayed.
