### PR TITLE
Update the whitelist for Dotclear 2.8.0

### DIFF
--- a/phpmalwarefinder
+++ b/phpmalwarefinder
@@ -7,24 +7,12 @@ NICE_BIN=$(which nice)
 
 if [ ! -f "$YARA" ]
 then
-        YARA='./yara'
+	YARA='./yara'
 fi
 
 if [ ! -f "$CONFIG_PATH" ]
 then
-        CONFIG_PATH='./malwares.yara'
-fi
-
-if [ -f "${IONICE_BIN}" ]
-then
-        NICE=${IONICE_BIN}
-        NICE_OPTS="-c 3"
-else
-        if [ -f "${NICE_BIN}" ]
-        then
-                NICE=${NICE_BIN}
-                NICE_OPTS="-n 20"
-        fi
+	CONFIG_PATH='./malwares.yara'
 fi
 
 if [ -f "${IONICE_BIN}" ]
@@ -85,16 +73,10 @@ then
     exit 1
 fi
 
-if [ ! -e ${NICE} ]
-then
-        echo "no nice programe available. PLease install ionice or nice."
-        exit 1
-fi
-
 if [ -z $@ ]
 then
-        show_help
-        exit 1
+	show_help
+	exit 1
 fi
 
 if [ ! -e ${NICE} ]

--- a/phpmalwarefinder
+++ b/phpmalwarefinder
@@ -2,15 +2,29 @@
 
 YARA=$(which yara)
 CONFIG_PATH='/etc/phpmalwarefinder/malwares.yara'
+IONICE_BIN=$(which ionice)
+NICE_BIN=$(which nice)
 
 if [ ! -f "$YARA" ]
 then
-	YARA='./yara'
+        YARA='./yara'
 fi
 
 if [ ! -f "$CONFIG_PATH" ]
 then
-	CONFIG_PATH='./malwares.yara'
+        CONFIG_PATH='./malwares.yara'
+fi
+
+if [ -f "${IONICE_BIN}" ]
+then
+        NICE=${IONICE_BIN}
+        NICE_OPTS="-c 3"
+else
+        if [ -f "${NICE_BIN}" ]
+        then
+                NICE=${NICE_BIN}
+                NICE_OPTS="-n 20"
+        fi
 fi
 
 show_help() {
@@ -59,12 +73,19 @@ then
     exit 1
 fi
 
+if [ ! -e ${NICE} ]
+then
+        echo "no nice programe available. PLease install ionice or nice."
+        exit 1
+fi
+
 if [ -z $@ ]
 then
-	show_help
-	exit 1
+        show_help
+        exit 1
 fi
 
 OPTS="${OPTS} -r ${CONFIG_PATH}"
 
-ionice -c3 $YARA $OPTS $@
+${NICE} ${NICE_OPTS} $YARA $OPTS $@
+

--- a/whitelist.yara
+++ b/whitelist.yara
@@ -84,6 +84,10 @@ private rule Concrete5
 private rule Dotclear : Blog
 {
     condition:
+        /* dotclear 2.8.0 */
+        hash.sha1(0, filesize) == "c732d2d54a80250fb8b51d4dddb74d05a59cee2e" or // inc/public/class.dc.template.php
+        hash.sha1(0, filesize) == "cc494f7f4044b5a3361281e27f2f7bb8952b8964" or // inc/core/class.dc.modules.php
+
         /* dotclear 2.7.5 */
         hash.sha1(0, filesize) == "192126b08c40c5ca086b5e4d7433e982f708baf3" or // inc/public/class.dc.template.php
         hash.sha1(0, filesize) == "51e6810ccd3773e2bd453e97ccf16059551bae08" or // inc/libs/clearbricks/common/lib.date.php


### PR DESCRIPTION
Dotclear 2.8.0 is out, and some whitelisted files changed. Here is an updated whitelist for this blog engine.
