### PR TITLE
Migrate to github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,8 @@ jobs:
 
       - name: Install apt dependencies
         run: |
-          apt-get update
-          apt-get  install -y devscripts fakeroot debhelper
+          sudo apt-get update
+          sudo apt-get  install -y devscripts fakeroot debhelper
 
       - name: Install YARA
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: Test
+
+on:
+  push:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install apt dependencies
+        run: |
+          apt-get update
+          apt-get  install -y devscripts fakeroot debhelper
+
+      - name: Install YARA
+        run: |
+          git clone --depth 1 https://github.com/plusvic/yara.git yara3
+          cd yara3
+          bash ./build.sh
+          ./configure
+          make
+          cp ./yara ../php-malware-finder/
+          cd ..
+
+      - name: Run tests
+        run: make tests
+
+      - name: Build debian package
+        run: make deb


### PR DESCRIPTION
Current link to Travis is broken and redirects to https://www.travis-ci.com/jvoisin/php-malware-finder which doesn't seem to exist, looks like they no longer provide free CI pipelines to open-source projects. Let's try to use GitHub's integrated CI.