### PR TITLE
Added support for white-spaces in target

### DIFF
--- a/php-malware-finder/phpmalwarefinder
+++ b/php-malware-finder/phpmalwarefinder
@@ -89,7 +89,8 @@ output=$(mktemp)
 # delete trailing slash for directories to prevent double slash (issue #40)
 target=$(echo "$@" | sed s'#/$##')
 # Execute rules
-$YARA $OPTS $target |tee $output 
+# Using $-interpolation and quotes to support a target with whitespaces
+$YARA $OPTS "$target" |tee $output 
 
 needle_in_haystack "$output"
 rm "$output"


### PR DESCRIPTION
I made the same fix in this forked repo:
https://github.com/nbs-system/php-malware-finder/pull/8

It might have something to do with the fact that I  run on WSL2 (or me being stupid). However, if the target directory for searching contains whitespace (no matter if they are escaped using ` "/some path/dir" ` or `/some \path/dir"` it causes errors.

Examples:
* Without this patch:
   * Sample 1
Input: 
`/c/Users/User/source/php-malware-finder/php-malware-finder/phpmalwarefinder -c "/c/Users/User/source/php-malware-finder/php-malware-finder/php.yar" -t 4 ~/white\ space\ test/php_malware_finder/test_1/`
 Output:
`error: could not open file: /home/alex/white`
   * Sample 2
Input:
`/c/Users/User/source/php-malware-finder/php-malware-finder/phpmalwarefinder -c "/c/Users/User/source/php-malware-finder/php-malware-finder/php.yar" -t 4 "white space test/php_malware_finder/test_1"`
Output:
`error: could not open file: white`

* With this patch:
   * Sample 1
Input:
 ` /c/Users/User/source/php-malware-finder/php-malware-finder/phpmalwarefinder -c "/c/Users/User/source/php-malware-finder/php-malware-finder/php.yar" -t 4 ~/white\ space\ test/php_malware_finder/test_1/`
Output (as expected):
`DodgyPhp /home/alex/white space test/php_malware_finder/test_1/aboba.php`
`ObfuscatedPhp /home/alex/white space test/php_malware_finder/test_1/SendMonthlyTaskListCompletionReminder.php`
   * Sample 2:
Input:
`/c/Users/User/source/php-malware-finder/php-malware-finder/phpmalwarefinder -c "/c/Users/User/source/php-malware-finder/php-malware-finder/php.yar" -t 4 "white space test/php_malware_finder/test_1"`
Output (as expected):
`DodgyPhp /home/alex/white space test/php_malware_finder/test_1/aboba.php`
`ObfuscatedPhp /home/alex/white space test/php_malware_finder/test_1/SendMonthlyTaskListCompletionReminder.php`