### PR TITLE
Compile rules from their location

### DIFF
--- a/php-malware-finder/phpmalwarefinder.go
+++ b/php-malware-finder/phpmalwarefinder.go
@@ -265,8 +265,10 @@ func main() {
 
 	// load YARA rules
 	rulePath := path.Join(args.RulesDir, RulesFile)
-	data, _ := ioutil.ReadFile(rulePath)
-	rules, _ := yara.Compile(string(data), nil)
+	data, err := ioutil.ReadFile(rulePath)
+	handleError(err, true)
+	rules, err := yara.Compile(string(data), nil)
+	handleError(err, true)
 	if args.Verbose {
 		log.Println("[DEBUG] ruleset loaded:", rulePath)
 	}

--- a/php-malware-finder/phpmalwarefinder.go
+++ b/php-malware-finder/phpmalwarefinder.go
@@ -210,6 +210,42 @@ func scanDir(dirName string, targets chan<- string, ticker <-chan time.Time) {
 	close(targets)
 }
 
+// loadRulesFile reads YARA rules from specified `fileName` and returns
+// them in their compiled form.
+func loadRulesFile(fileName string) (*yara.Rules, error) {
+	var err error = nil
+	// record working directory and move to rules location
+	curDir, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("unable to determine working directory: %v", err)
+	}
+	ruleDir, ruleName := filepath.Split(fileName)
+	err = os.Chdir(ruleDir)
+	if err != nil {
+		return nil, fmt.Errorf("unable to move to rules directory: %v", err)
+	}
+
+	// read file content
+	data, err := ioutil.ReadFile(ruleName)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read rules file: %v", err)
+	}
+
+	// compile rules
+	rules, err := yara.Compile(string(data), nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to load rules: %v", err)
+	}
+
+	// move back to working directory
+	err = os.Chdir(curDir)
+	if err != nil {
+		return nil, fmt.Errorf("unable to move back to working directory: %v", err)
+	}
+
+	return rules, nil
+}
+
 func main() {
 	startTime := time.Now()
 	_, err := flags.Parse(&args)
@@ -265,9 +301,7 @@ func main() {
 
 	// load YARA rules
 	rulePath := path.Join(args.RulesDir, RulesFile)
-	data, err := ioutil.ReadFile(rulePath)
-	handleError(err, true)
-	rules, err := yara.Compile(string(data), nil)
+	rules, err := loadRulesFile(rulePath)
 	handleError(err, true)
 	if args.Verbose {
 		log.Println("[DEBUG] ruleset loaded:", rulePath)


### PR DESCRIPTION
As the main rules file includes other files, the rules compilation must happen from their folder. This PR adds a function that moves to the rules folder, loads and compiles the rules, and moves back to the initial working directory.

This fixes #115.