### PR TITLE
Fix Docker image build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,22 +2,8 @@ FROM golang:alpine as build
 WORKDIR /app
 
 # install build dependencies
-RUN apk add --no-cache \
-    build-base \
-    automake \
-    autoconf \
-    pkgconfig \
-    libtool \
-    bison \
-    libressl-dev \
-    git
-
-# install YARA
-RUN git clone --depth 1 https://github.com/virustotal/yara.git \
-    && cd yara \
-    && sh ./build.sh \
-    && make install \
-    && cd ..
+RUN apk add --no-cache build-base git && \
+    apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/testing yara-dev
 
 # copy and build PMF
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/jvoisin/php-malware-finder
 go 1.16
 
 require (
-	github.com/hillu/go-yara/v4 v4.2.3
+	github.com/hillu/go-yara/v4 v4.2.4
 	github.com/jessevdk/go-flags v1.5.0
 )
 
-require golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
+require golang.org/x/sys v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
-github.com/hillu/go-yara/v4 v4.2.3 h1:Gazusex0rkL8NCMjc2vXqKBIHZ4kiBlLdMt2DuvhL4A=
-github.com/hillu/go-yara/v4 v4.2.3/go.mod h1:AHEs/FXVMQKVVlT6iG9d+q1BRr0gq0WoAWZQaZ0gS7s=
+github.com/hillu/go-yara/v4 v4.2.4 h1:r3KB1XV+h6q+N8bvK6/gLpxAVcd6baYzmOSYHzNo9QQ=
+github.com/hillu/go-yara/v4 v4.2.4/go.mod h1:AHEs/FXVMQKVVlT6iG9d+q1BRr0gq0WoAWZQaZ0gS7s=
 github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LFvc=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
-golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
+golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
This PR fixes the docker image build error by using the `yara-dev` package from alpine testing repo instead of compiling YARA from git.

Also updates go-yara to the latest version.