### PR TITLE
Drop support for Go 1.16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ jobs:
     strategy:
       matrix:
         go_version:
-          - '~1.16'
           - '~1.17'
           - '^1.18'
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ and then passed to some dangerous function like `system`".
 
 ### From source
 
-- Install Go (using your package manager, or [manually](https://go.dev/doc/install))
+- Install Go >= 1.17 (using your package manager, or [manually](https://go.dev/doc/install))
 - Install libyara >= 4.2 (using your package manager, or [from source](https://yara.readthedocs.io/en/stable/gettingstarted.html))
 - Download php-malware-finder: `git clone https://github.com/jvoisin/php-malware-finder.git`
 - Build php-malware-finder: `cd php-malware-finder && make`

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jvoisin/php-malware-finder
 
-go 1.16
+go 1.17
 
 require (
 	github.com/hillu/go-yara/v4 v4.2.4


### PR DESCRIPTION
Latest dependencies require at least Go 1.17, this PR updates the minimal version and removes the tests for 1.16 (which are now [failing](https://github.com/jvoisin/php-malware-finder/actions/runs/3841775592/jobs/6542378251))